### PR TITLE
Make transcription language picker explicitly scrollable

### DIFF
--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -20,6 +20,119 @@ import '../widgets/ink_toggle.dart';
 import '../widgets/settings_rows.dart';
 import 'backup_screen.dart';
 
+/// A bounded language chooser with an explicit, draggable scroll affordance.
+///
+/// [SimpleDialog] makes its choices scrollable, but does not show that a long
+/// list continues below the fold. Once the supported-language set outgrew a
+/// phone-height dialog, choices after the first screen (starting with Italian
+/// on common devices) were effectively hidden. This picker owns its controller
+/// so the thumb is always visible and usable on touch and desktop.
+class _LanguagePickerDialog extends StatefulWidget {
+  const _LanguagePickerDialog({required this.selectedLanguage});
+
+  final String? selectedLanguage;
+
+  @override
+  State<_LanguagePickerDialog> createState() =>
+      _LanguagePickerDialogState();
+}
+
+class _LanguagePickerDialogState extends State<_LanguagePickerDialog> {
+  final _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(
+          minWidth: 280,
+          maxWidth: 420,
+          maxHeight: 560,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 24, 24, 12),
+              child: Text(
+                context.l10n.transcriptionLanguageTitle,
+                style: Theme.of(context).dialogTheme.titleTextStyle,
+              ),
+            ),
+            Flexible(
+              child: Scrollbar(
+                key: const Key('language-picker-scrollbar'),
+                controller: _scrollController,
+                thumbVisibility: true,
+                trackVisibility: true,
+                interactive: true,
+                child: ListView(
+                  key: const Key('language-picker-list'),
+                  controller: _scrollController,
+                  shrinkWrap: true,
+                  padding: const EdgeInsets.fromLTRB(0, 0, 8, 16),
+                  children: [
+                    _option(
+                      context,
+                      label: context.l10n.autoDetectOption,
+                      selected: widget.selectedLanguage == null,
+                      result: 'auto',
+                    ),
+                    for (final entry in SettingsScreen.languages.entries)
+                      _option(
+                        context,
+                        label: entry.value,
+                        selected: widget.selectedLanguage == entry.key,
+                        result: entry.key,
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _option(
+    BuildContext context, {
+    required String label,
+    required bool selected,
+    required String result,
+  }) =>
+      SimpleDialogOption(
+        onPressed: () => Navigator.pop(context, result),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 22,
+              child: selected
+                  ? Icon(Icons.check, size: 16, color: context.tape.ink)
+                  : null,
+            ),
+            Expanded(
+              child: Text(
+                label,
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: selected ? FontWeight.w700 : null,
+                  color: context.tape.ink,
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+}
+
 /// Settings (§5.5, mockup 05): grouped ink-bordered cards, rectangular
 /// toggles. Model & backup rows are honest about what ships in M1.
 class SettingsScreen extends ConsumerWidget {
@@ -136,23 +249,8 @@ class SettingsScreen extends ConsumerWidget {
       BuildContext context, SettingsRepository repo, AppSettings s) async {
     final choice = await showDialog<String>(
       context: context,
-      builder: (dialogContext) => SimpleDialog(
-        title: Text(context.l10n.transcriptionLanguageTitle),
-        children: [
-          _dialogOption(
-            dialogContext,
-            label: context.l10n.autoDetectOption,
-            selected: s.appLanguage == null,
-            result: 'auto',
-          ),
-          for (final entry in languages.entries)
-            _dialogOption(
-              dialogContext,
-              label: entry.value,
-              selected: s.appLanguage == entry.key,
-              result: entry.key,
-            ),
-        ],
+      builder: (_) => _LanguagePickerDialog(
+        selectedLanguage: s.appLanguage,
       ),
     );
     if (choice != null) {
@@ -701,4 +799,3 @@ class _PickerOption extends StatelessWidget {
     );
   }
 }
-

--- a/test/presentation/language_picker_test.dart
+++ b/test/presentation/language_picker_test.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+
+import 'package:diktafon/application/providers.dart';
+import 'package:diktafon/data/db/database.dart';
+import 'package:diktafon/data/repositories/settings_repository.dart';
+import 'package:diktafon/l10n/l10n.dart';
+import 'package:diktafon/presentation/screens/settings_screen.dart';
+import 'package:diktafon/presentation/theme/theme.dart';
+import 'package:diktafon/services/providers/llm/llm_model_manager.dart';
+import 'package:diktafon/services/providers/whisper/whisper_model_manager.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory modelDir;
+  late AppDatabase db;
+
+  setUp(() {
+    modelDir = Directory.systemTemp.createTempSync('dk_language_picker_');
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+    modelDir.deleteSync(recursive: true);
+  });
+
+  Widget app() => ProviderScope(
+    overrides: [
+      appDatabaseProvider.overrideWithValue(db),
+      whisperModelManagerProvider.overrideWithValue(
+        WhisperModelManager(modelDir),
+      ),
+      llmModelManagerProvider.overrideWithValue(LlmModelManager(modelDir)),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('en'),
+      theme: buildTheme(Brightness.light),
+      home: const SettingsScreen(),
+    ),
+  );
+
+  testWidgets('long language picker scrolls to and selects Italian', (
+    tester,
+  ) async {
+    // Short phone viewport: Italian begins below the first visible choices,
+    // reproducing the language-wave-2 picker regression.
+    tester.view.physicalSize = const Size(360, 520);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(app());
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.text('Transcription language'));
+    await tester.pump();
+    await tester.pump();
+
+    final scrollbar = tester.widget<Scrollbar>(
+      find.byKey(const Key('language-picker-scrollbar')),
+    );
+    expect(
+      scrollbar.thumbVisibility,
+      isTrue,
+      reason: 'the dialog must advertise that more languages follow',
+    );
+    expect(scrollbar.trackVisibility, isTrue);
+
+    final list = find.byKey(const Key('language-picker-list'));
+    final scrollable = find.descendant(
+      of: list,
+      matching: find.byType(Scrollable),
+    );
+    expect(
+      tester.state<ScrollableState>(scrollable).position.maxScrollExtent,
+      greaterThan(0),
+    );
+
+    await tester.scrollUntilVisible(
+      find.text('Italiano'),
+      180,
+      scrollable: scrollable,
+    );
+    await tester.tap(find.text('Italiano'));
+    await tester.pumpAndSettle();
+
+    expect((await SettingsRepository(db).get()).appLanguage, 'it');
+    expect(
+      find.text('Italiano'),
+      findsOneWidget,
+      reason: 'the Settings row mirrors the persisted Whisper override',
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 1));
+  });
+}


### PR DESCRIPTION
## Summary

- replace the implicitly scrolling language dialog with a bounded list
- add an always-visible, interactive scrollbar so languages below the fold, including Italian, are discoverable and selectable
- preserve the existing language-code persistence and selected-state behavior

## Testing

- `flutter analyze --no-pub`
- `flutter test --no-pub test/presentation/language_picker_test.dart`
- built and installed the arm64 debug APK on a Samsung SM-S938B; manually confirmed scrolling to and selecting Italian works
